### PR TITLE
gitlib-s3 smoke tests use environment variables

### DIFF
--- a/gitlib-s3/test/Smoke.hs
+++ b/gitlib-s3/test/Smoke.hs
@@ -26,9 +26,10 @@ import           Test.Hspec.Runner
 
 main :: IO ()
 main = do
-    bucket    <- return Nothing -- fmap T.pack <$> lookupEnv "S3_BUCKET"
-    accessKey <- return Nothing -- fmap T.pack <$> lookupEnv "AWS_ACCESS_KEY"
-    secretKey <- return Nothing -- fmap T.pack <$> lookupEnv "AWS_SECRET_KEY"
+    env <- getEnvironment
+    let bucket    = T.pack <$> lookup "S3_BUCKET" env
+        accessKey = T.pack <$> lookup "AWS_ACCESS_KEY" env
+        secretKey = T.pack <$> lookup "AWS_SECRET_KEY" env
     summary   <-
         hspecWith
         (defaultConfig { configVerbose = True })


### PR DESCRIPTION
[This change](https://github.com/fpco/gitlib/commit/0b7f3064fb34dff6029f40335ffaf881480bb746#L8R29) seems to have broken the gitlib-s3 smoke tests: .  This pull request undoes that change and also makes it build with HP 2012.4 (which doesn't have `System.Environment.lookupEnv`).
