### PR TITLE
README.md: fix formatting for display on Github

### DIFF
--- a/hlibgit2/README.md
+++ b/hlibgit2/README.md
@@ -1,7 +1,9 @@
 To install the libgit package run as root:
+
     build.sh
 
 run cabal
+
     cabal configure --enable-test
     cabal build
     cabal test


### PR DESCRIPTION
Currently, at least on Github, the code blocks aren't formatted as such. Fix this.
