### PR TITLE
missing pthread dependency

### DIFF
--- a/hlibgit2/hlibgit2.cabal
+++ b/hlibgit2/hlibgit2.cabal
@@ -233,4 +233,4 @@ Library
     include-dirs:
       libgit2/src/unix
     extra-libraries:
-      ssl, crypto
+      ssl, crypto, pthread


### PR DESCRIPTION
I get errors when trying to compile using gitlib-libgit2:

Linking git-tool ...
/usr/bin/ld: /home/james/lib/haskell/cabal/lib/hlibgit2-0.18.0.13/ghc-7.8.3/libHShlibgit2-0.18.0.13.a(global.o): referencia sin definir al símbolo 'pthread_key_delete@@GLIBC_2.2.5'
/lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status

Adding pthread to the extra-libraries for hlibgit2 fixes this problem.
