### PR TITLE
fix ambiguous type errors when using treeEntryToOid

### DIFF
--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -202,7 +202,7 @@ data TreeEntry r = BlobEntry   { blobEntryOid   :: !(BlobOid r)
 --     show (TreeEntry oid)   = "<TreeEntry " ++ show oid ++ ">"
 --     show (CommitEntry oid) = "<CommitEntry " ++ show oid ++ ">"
 
-treeEntryToOid :: MonadGit r m => TreeEntry r -> Oid r
+treeEntryToOid :: TreeEntry r -> Oid r
 treeEntryToOid (BlobEntry boid _) = untag boid
 treeEntryToOid (TreeEntry toid)   = untag toid
 treeEntryToOid (CommitEntry coid) = untag coid


### PR DESCRIPTION
I get ambiguous type errors whenever I try and use "treeEntryToOid". Removing the MonadGit bit from the type of the function fixes this. Not sure if this is the right fix, since I'm new to Haskell, but it's my best bet, since the types are already constrained enough I think.
