### PR TITLE
Make git a test dependency of hlibgit2.

### DIFF
--- a/hlibgit2/Setup.hs
+++ b/hlibgit2/Setup.hs
@@ -1,2 +1,6 @@
-import Distribution.Simple
-main = defaultMain
+import           Distribution.Simple
+import           Distribution.Simple.Program
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+       { hookedPrograms = [ simpleProgram "git" ]}

--- a/hlibgit2/hlibgit2.cabal
+++ b/hlibgit2/hlibgit2.cabal
@@ -6,7 +6,7 @@ License-file:        LICENSE
 License:             MIT
 Author:              John Wiegley, Sakari Jokinen, Jacob Stanleyyeah,
 Maintainer:          johnw@newartisans.com
-Build-Type:          Simple
+Build-Type:          Custom
 Cabal-Version:       >=1.10
 Category:            FFI
 
@@ -37,6 +37,8 @@ Test-suite smoke
       base >=3
     , hlibgit2
     , process
+  build-tools:
+    git
 
 Library
   hs-source-dirs: .


### PR DESCRIPTION
This is based on the change in jgm/zip-archive#22 which was solving a similar issue---having cabal truly depend on an external tool.

Incidentally, `cabal2nix` now recognizes these dependencies and puts them in its generated expression; if you want, I'm happy to apply this change to gitlib-cmdline as well.