### PR TITLE
Make git a test dependency of gitlib-cmdline.

### DIFF
--- a/gitlib-cmdline/Setup.hs
+++ b/gitlib-cmdline/Setup.hs
@@ -1,2 +1,6 @@
-import Distribution.Simple
-main = defaultMain
+import           Distribution.Simple
+import           Distribution.Simple.Program
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+       { hookedPrograms = [ simpleProgram "git" ]}

--- a/gitlib-cmdline/gitlib-cmdline.cabal
+++ b/gitlib-cmdline/gitlib-cmdline.cabal
@@ -6,7 +6,7 @@ License-file:        LICENSE
 License:             MIT
 Author:              John Wiegley
 Maintainer:          johnw@newartisans.com
-Build-Type:          Simple
+Build-Type:          Custom
 Cabal-Version:       >=1.10
 Category:            Git
 
@@ -61,3 +61,5 @@ Test-suite smoke
     , tagged             >= 0.2.3.1
     , text               >= 0.11.2
     , transformers       >= 0.2.2
+  build-tools:
+    git


### PR DESCRIPTION
Do it at the cabal level, so the nix expressions can easily be
regenerated without fixups.