### PR TITLE
Improve Windows compatibility

### DIFF
--- a/gitlib/Git/Tree/Working.hs
+++ b/gitlib/Git/Tree/Working.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Git.Tree.Working where
 
 import           Control.Applicative
@@ -18,7 +19,11 @@ import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Git hiding (Options)
 import           Prelude hiding (log)
 import           System.FilePath.Posix
+#ifndef mingw32_HOST_OS
 import           System.Posix.Files
+#else
+import           System.PosixCompat.Files
+#endif
 
 data FileEntry m = FileEntry
     { fileModTime  :: UTCTime

--- a/gitlib/gitlib.cabal
+++ b/gitlib/gitlib.cabal
@@ -63,6 +63,9 @@ Library
     if !os(mingw32)
         build-depends:
           unix                 >= 2.5.1.1
+    else
+        build-depends:
+          unix-compat          >= 0.4
     exposed-modules:
         Git
         Git.Blob

--- a/hlibgit2/Bindings/Libgit2/Windows.hsc
+++ b/hlibgit2/Bindings/Libgit2/Windows.hsc
@@ -3,6 +3,7 @@
 module Bindings.Libgit2.Windows where
 
 #ifdef GIT_WIN32
+#strict_import
 #ccall gitwin_set_codepage , CUInt -> IO ()
 #ccall gitwin_get_codepage , IO (CUInt)
 #ccall gitwin_set_utf8 , IO ()

--- a/hlibgit2/hlibgit2.cabal
+++ b/hlibgit2/hlibgit2.cabal
@@ -229,6 +229,8 @@ Library
       libgit2/src/win32/utf-conv.c
     include-dirs:
       libgit2/src/win32
+    extra-libraries:
+      ws2_32, regex, winhttp, crypt32, rpcrt4, ssl, crypto
   else
     cc-options: -D_GNU_SOURCE -DOPENSSL_SHA1 -Wno-deprecated-declarations
     c-sources:


### PR DESCRIPTION
This patch improves Windows compatibility of this library. It's basically the same as https://github.com/jwiegley/gitlib/issues/50 .

I also faced to [stack(or hsc2hs)'s bug](https://github.com/commercialhaskell/stack/issues/1540#issuecomment-170185997). I had to use following workaround:

```
$ touch hlibgit2/BindingsLibgit2Windows.hsc
```