### PR TITLE
Avoid using deprecated conduit functions

### DIFF
--- a/gitlib/Git/Commit.hs
+++ b/gitlib/Git/Commit.hs
@@ -67,9 +67,9 @@ listCommits :: MonadGit r m
             -> CommitOid r         -- ^ The commit we need
             -> m [CommitOid r]     -- ^ All the objects in between
 listCommits mhave need =
-    sourceObjects mhave need False
-        $= mapMC (\(CommitObjOid c) -> return c)
-        $$ sinkList
+    runConduit $ sourceObjects mhave need False
+        .| mapMC (\(CommitObjOid c) -> return c)
+        .| sinkList
 
 traverseCommits :: MonadGit r m => (CommitOid r -> m a) -> CommitOid r -> m [a]
 traverseCommits f need = mapM f =<< listCommits Nothing need

--- a/gitlib/Git/Object.hs
+++ b/gitlib/Git/Object.hs
@@ -13,7 +13,7 @@ listObjects :: MonadGit r m
             -> Bool                -- ^ Include commit trees also?
             -> m [ObjectOid r]     -- ^ All the objects in between
 listObjects mhave need alsoTrees =
-    sourceObjects mhave need alsoTrees $$ sinkList
+    runConduit $ sourceObjects mhave need alsoTrees .| sinkList
 
 traverseObjects :: MonadGit r m => (ObjectOid r -> m a) -> CommitOid r -> m [a]
 traverseObjects f need = mapM f =<< listObjects Nothing need False
@@ -24,13 +24,13 @@ traverseObjects_ = (void .) . traverseObjects
 -- | Given a list of objects (commit and top-level trees) return by
 --   'listObjects', expand it to include all subtrees and blobs as well.
 --   Ordering is preserved.
-expandTreeObjects :: MonadGit r m => Conduit (ObjectOid r) m (ObjectOid r)
+expandTreeObjects :: MonadGit r m => ConduitT (ObjectOid r) (ObjectOid r) m ()
 expandTreeObjects = awaitForever $ \obj -> case obj of
     TreeObjOid toid -> do
         yield $ TreeObjOid toid
         tr <- lift $ lookupTree toid
         sourceTreeEntries tr
-            =$= awaitForever (\ent -> case ent of
+            .| awaitForever (\ent -> case ent of
                 (_, BlobEntry oid _) -> yield $ BlobObjOid oid
                 (_, TreeEntry oid)   -> yield $ TreeObjOid oid
                 _ -> return ())
@@ -39,4 +39,4 @@ expandTreeObjects = awaitForever $ \obj -> case obj of
 listAllObjects :: MonadGit r m
                => Maybe (CommitOid r) -> CommitOid r -> m [ObjectOid r]
 listAllObjects mhave need =
-    sourceObjects mhave need True $= expandTreeObjects $$ sinkList
+    runConduit $ sourceObjects mhave need True .| expandTreeObjects .| sinkList

--- a/gitlib/Git/Reference.hs
+++ b/gitlib/Git/Reference.hs
@@ -4,7 +4,7 @@ import Conduit
 import Git.Types
 
 listReferences :: MonadGit r m => m [RefName]
-listReferences = sourceReferences $$ sinkList
+listReferences = runConduit $ sourceReferences .| sinkList
 
 resolveReference :: MonadGit r m => RefName -> m (Maybe (Oid r))
 resolveReference name = do

--- a/gitlib/Git/Tree.hs
+++ b/gitlib/Git/Tree.hs
@@ -12,7 +12,7 @@ import           Git.Tree.Builder
 import           Git.Types
 
 listTreeEntries :: MonadGit r m => Tree r -> m [(TreeFilePath, TreeEntry r)]
-listTreeEntries tree = sourceTreeEntries tree $$ sinkList
+listTreeEntries tree = runConduit $ sourceTreeEntries tree .| sinkList
 
 copyTreeEntry :: (MonadGit r m, MonadGit s (t m), MonadTrans t)
               => TreeEntry r -> HashSet Text -> t m (TreeEntry s, HashSet Text)

--- a/gitlib/gitlib.cabal
+++ b/gitlib/gitlib.cabal
@@ -43,7 +43,7 @@ Library
           base                 >= 3 && < 5
         , base16-bytestring    >= 0.1.1.5
         , bytestring           >= 0.9.2.1
-        , conduit              >= 1.1.0
+        , conduit              >= 1.2.8
         , conduit-combinators  >= 1
         , containers           >= 0.4.2.1
         , directory            >= 1.1.0.2


### PR DESCRIPTION
Some type synonyms (`Producer`, `Source`, etc.) and some functions (`$$`, `$=`, etc.) were deprecated, and [`.|`](https://hackage.haskell.org/package/conduit-1.3.0.2/docs/Data-Conduit.html#v:.-124-) was introduced in conduit-1.2.8.