### PR TITLE
Migrate to unliftio, away from monad-control

### DIFF
--- a/git-monitor/git-monitor.cabal
+++ b/git-monitor/git-monitor.cabal
@@ -37,7 +37,6 @@ Executable git-monitor
                  , time                 >= 1.4
                  , transformers         >= 0.3.0.0
                  , unordered-containers >= 0.2.3.0
-                 , lifted-async         >= 0.1.1
                  , unix
 
 Source-repository head

--- a/gitlib-cmdline/gitlib-cmdline.cabal
+++ b/gitlib-cmdline/gitlib-cmdline.cabal
@@ -27,7 +27,6 @@ Library
     , containers           >= 0.4.2.1
     , directory            >= 1.1.0.2
     , exceptions           >= 0.5
-    , monad-control        <  1.1
     , mtl                  >= 2.1.2
     , old-locale           >= 1.0.0.4
     , parsec               >= 3.1.3

--- a/gitlib-libgit2/Git/Libgit2/Types.hs
+++ b/gitlib-libgit2/Git/Libgit2/Types.hs
@@ -13,7 +13,6 @@ import           Control.Applicative
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
 import           Control.Monad.IO.Unlift
-import           Control.Monad.Trans.Control
 import           Data.IORef
 import           Foreign.ForeignPtr
 import qualified Git
@@ -54,7 +53,6 @@ type Options     = Git.Options LgRepo
 
 type MonadExcept m = (MonadThrow m, MonadCatch m, MonadMask m)
 
-type MonadLg m = (Applicative m, MonadExcept m,
-                  MonadIO m, MonadBaseControl IO m, MonadUnliftIO m)
+type MonadLg m = (Applicative m, MonadExcept m, MonadUnliftIO m)
 
 -- Types.hs

--- a/gitlib-libgit2/gitlib-libgit2.cabal
+++ b/gitlib-libgit2/gitlib-libgit2.cabal
@@ -48,10 +48,7 @@ Library
         , exceptions           >= 0.6
         , fast-logger
         , filepath             >= 1.3.0
-        , lifted-async         >= 0.1.0
-        , lifted-base          >= 0.2.0.2
         , mmorph               >= 1.0.0
-        , monad-control        >= 1.0
         , monad-loops          >= 0.3.3.0
         , mtl                  >= 2.1.2
         , resourcet            >= 1.1.0
@@ -65,6 +62,7 @@ Library
         , transformers         >= 0.3.0.0
         , transformers-base    >= 0.4.1
         , unliftio-core        >= 0.1.1
+        , unliftio
     exposed-modules:
         Git.Libgit2
         Git.Libgit2.Backend

--- a/gitlib-test/gitlib-test.cabal
+++ b/gitlib-test/gitlib-test.cabal
@@ -29,10 +29,10 @@ Library
         , exceptions           >= 0.5
         , conduit              >= 1.1.0
         , conduit-combinators  >= 1
-        , monad-control        <  1.1
         , tagged               >= 0.4.4
         , text                 >= 0.11.2
         , time                 >= 1.4
         , transformers         >= 0.3
+        , unliftio-core        >= 0.1.1
     exposed-modules:
         Git.Smoke

--- a/gitlib/Git/Commit/Push.hs
+++ b/gitlib/Git/Commit/Push.hs
@@ -4,8 +4,8 @@ import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.Catch
 import           Control.Monad.IO.Class
+import           Control.Monad.IO.Unlift
 import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Control
 import           Data.Function
 import qualified Data.HashSet as HashSet
 import           Data.List
@@ -46,8 +46,8 @@ pushCommit coid remoteRefName = do
     -- updateReference_ remoteRefName (RefObj cref)
     return cref
 
-copyRepository :: (MonadGit r m, MonadIO m, MonadBaseControl IO m,
-                   MonadGit s (t m), MonadTrans t, MonadBaseControl IO (t m))
+copyRepository :: (MonadGit r m, MonadUnliftIO m,
+                   MonadGit s (t m), MonadTrans t, MonadUnliftIO (t m))
                 => RepositoryFactory (t m) m s
                 -> Maybe (CommitOid r)
                 -> Text

--- a/gitlib/Git/Repository.hs
+++ b/gitlib/Git/Repository.hs
@@ -1,13 +1,13 @@
 module Git.Repository where
 
-import Control.Exception.Lifted
 import Control.Monad
 import Control.Monad.IO.Class
-import Control.Monad.Trans.Control
+import Control.Monad.IO.Unlift
 import Git.Types
 import System.Directory
+import UnliftIO.Exception
 
-withNewRepository :: (MonadGit r n, MonadBaseControl IO n, MonadIO m)
+withNewRepository :: (MonadGit r n, MonadUnliftIO n, MonadUnliftIO m)
                   => RepositoryFactory n m r
                   -> FilePath -> n a -> m a
 withNewRepository factory path action = do
@@ -29,8 +29,7 @@ withNewRepository factory path action = do
 
     return a
 
-withNewRepository' :: (MonadGit r n, MonadBaseControl IO n,
-                       MonadBaseControl IO m, MonadIO m)
+withNewRepository' :: (MonadGit r n, MonadUnliftIO n, MonadUnliftIO m)
                    => RepositoryFactory n m r -> FilePath -> n a -> m a
 withNewRepository' factory path action =
     bracket_ recover recover $
@@ -45,13 +44,13 @@ withNewRepository' factory path action =
         exists <- doesDirectoryExist path
         when exists $ removeDirectoryRecursive path
 
-withRepository' :: (MonadGit r n, MonadBaseControl IO n, MonadIO m)
+withRepository' :: (MonadGit r n, MonadUnliftIO n, MonadUnliftIO m)
                 => RepositoryFactory n m r -> RepositoryOptions -> n a -> m a
 withRepository' factory opts action = do
     repo <- openRepository factory opts
     runRepository factory repo $ action `finally` closeRepository
 
-withRepository :: (MonadGit r n, MonadBaseControl IO n, MonadIO m)
+withRepository :: (MonadGit r n, MonadUnliftIO n, MonadUnliftIO m)
                => RepositoryFactory n m r -> FilePath -> n a -> m a
 withRepository factory path =
     withRepository' factory defaultRepositoryOptions { repoPath = path }

--- a/gitlib/Git/Tree/Working.hs
+++ b/gitlib/Git/Tree/Working.hs
@@ -2,11 +2,12 @@
 module Git.Tree.Working where
 
 import           Control.Applicative
-import           Control.Concurrent.Async.Lifted
+-- import           Control.Concurrent.Async.Lifted
 import           Control.Exception
 import           Control.Monad
 import           Control.Monad.IO.Class (MonadIO(..))
-import           Control.Monad.Trans.Control
+import           Control.Monad.IO.Unlift
+-- import           Control.Monad.Trans.Control
 import qualified Data.ByteString as B (readFile)
 import qualified Data.ByteString.Char8 as B8
 import           Data.Foldable (foldl')
@@ -18,6 +19,7 @@ import           Data.Time
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Git hiding (Options)
 import           Prelude hiding (log)
+import           UnliftIO.Async
 import           System.FilePath.Posix
 #ifndef mingw32_HOST_OS
 import           System.Posix.Files
@@ -34,7 +36,7 @@ data FileEntry m = FileEntry
 
 type FileTree m = HashMap TreeFilePath (FileEntry m)
 
-readFileTree :: (MonadBaseControl IO m, MonadIO m, MonadGit r m)
+readFileTree :: (MonadGit r m, MonadUnliftIO m)
              => RefName
              -> FilePath
              -> Bool
@@ -47,7 +49,7 @@ readFileTree ref wdir getHash = do
             tr <- lookupTree . commitTree =<< lookupCommit (Tagged h')
             readFileTree' tr wdir getHash
 
-readFileTree' :: (MonadBaseControl IO m, MonadIO m, MonadGit r m)
+readFileTree' :: (MonadGit r m, MonadUnliftIO m)
               => Tree r -> FilePath -> Bool
               -> m (FileTree r)
 readFileTree' tr wdir getHash = do

--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -7,7 +7,7 @@ module Git.Types where
 
 import           Conduit
 import           Control.Applicative
-import qualified Control.Exception.Lifted as Exc
+import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Trans.State
 import           Data.ByteString (ByteString)
@@ -435,4 +435,4 @@ data GitException
 -- jww (2013-02-11): Create a BackendException data constructor of forall
 -- e. Exception e => BackendException e, so that each can throw a derived
 -- exception.
-instance Exc.Exception GitException
+instance Exception GitException

--- a/gitlib/Git/Working.hs
+++ b/gitlib/Git/Working.hs
@@ -5,7 +5,6 @@ module Git.Working where
 import Conduit
 import Control.Applicative
 import Control.Monad.Catch
-import Control.Monad.Trans.Control
 import Data.Semigroup
 import Data.Text as T
 import Git.Blob
@@ -16,8 +15,7 @@ import System.FilePath
 import System.Posix.Files
 #endif
 
-checkoutFiles :: (MonadGit r m, MonadBaseControl IO m, MonadIO m,
-                  MonadResource m)
+checkoutFiles :: (MonadGit r m, MonadResource m)
               => FilePath
               -> Tree r
               -> (TreeFilePath -> Either String FilePath)

--- a/gitlib/gitlib.cabal
+++ b/gitlib/gitlib.cabal
@@ -50,9 +50,6 @@ Library
         , exceptions           >= 0.5
         , filepath             >= 1.3
         , hashable             >= 1.1.2.5
-        , lifted-async         >= 0.1.1
-        , lifted-base          >= 0.2
-        , monad-control        <  1.1
         , mtl                  >= 2.1.2
         , resourcet            >= 1.1.0
         , semigroups           >= 0.11
@@ -61,6 +58,8 @@ Library
         , time                 >= 1.4
         , transformers         >= 0.3.0.0
         , unordered-containers >= 0.2.3.0
+        , unliftio-core        >= 0.1.1
+        , unliftio
     if !os(mingw32)
         build-depends:
           unix                 >= 2.5.1.1


### PR DESCRIPTION
Hi! Thanks for the great libraries.

Due to changes in the conduit/resourcet ecosystem, a lot of things now no longer work with monad-control/MonadBaseControl functions (some instances have appeared to disappear from those libraries), so I've tried my best to see if it makes sense to move the entire library to unliftio/MonadUnliftIO style.  Things seem to have been pretty straightforward!

Let me know if this isn't the direction you want to go, or if there's anything I can touch up!