### PR TITLE
Fix flag issue with GCC 7.

### DIFF
--- a/hlibgit2/hlibgit2.cabal
+++ b/hlibgit2/hlibgit2.cabal
@@ -212,7 +212,7 @@ Library
     libgit2/src
     libgit2/deps/http-parser
 
-  cc-options: -DGIT_THREADS -D_FILE_OFFSET_BITS=64 -DGIT_SSL -Wno-format
+  cc-options: -DGIT_THREADS -D_FILE_OFFSET_BITS=64 -DGIT_SSL -Wno-format -Wno-format-security
   if os(windows)
     cpp-options: -DWINDOWS
     cc-options: -DGIT_WIN32 -DWIN32 -DWIN32_SHA1 -D_DEBUG -D_WIN32_WINNT=0x0501 -DGIT_WINHTTP


### PR DESCRIPTION
Without the `-Wno-format-security` flag, GCC 7 fails with this error:

```
cc1: error: -Wformat-security ignored without -Wformat [-Werror=format-security]
```