### PR TITLE
Get rid of custom Setup.hs files

### DIFF
--- a/gitlib-cmdline/Setup.hs
+++ b/gitlib-cmdline/Setup.hs
@@ -1,6 +1,2 @@
-import           Distribution.Simple
-import           Distribution.Simple.Program
-
-main :: IO ()
-main = defaultMainWithHooks simpleUserHooks
-       { hookedPrograms = [ simpleProgram "git" ]}
+import Distribution.Simple
+main = defaultMain

--- a/gitlib-cmdline/gitlib-cmdline.cabal
+++ b/gitlib-cmdline/gitlib-cmdline.cabal
@@ -6,7 +6,7 @@ License-file:        LICENSE
 License:             MIT
 Author:              John Wiegley
 Maintainer:          johnw@newartisans.com
-Build-Type:          Custom
+Build-Type:          Simple
 Cabal-Version:       >=1.10
 Category:            Git
 

--- a/hlibgit2/Setup.hs
+++ b/hlibgit2/Setup.hs
@@ -1,6 +1,2 @@
-import           Distribution.Simple
-import           Distribution.Simple.Program
-
-main :: IO ()
-main = defaultMainWithHooks simpleUserHooks
-       { hookedPrograms = [ simpleProgram "git" ]}
+import Distribution.Simple
+main = defaultMain

--- a/hlibgit2/hlibgit2.cabal
+++ b/hlibgit2/hlibgit2.cabal
@@ -6,7 +6,7 @@ License-file:        LICENSE
 License:             MIT
 Author:              John Wiegley, Sakari Jokinen, Jacob Stanleyyeah,
 Maintainer:          johnw@newartisans.com
-Build-Type:          Custom
+Build-Type:          Simple
 Cabal-Version:       >=1.10
 Category:            FFI
 


### PR DESCRIPTION
As mentioned [here](https://github.com/jwiegley/gitlib/commit/bd26e038aca158e19af32340ec8a58bc7b13dda3#commitcomment-33953077), custom Setup.hs files cause problems for cabal v2-build.

The build-tools stanzas are also deprecated but don't seem to be causing any problems right now, so I've left them alone.

This partially reverts commit 76d8be594abf1341561ed212736c5e28dd940708
and commit bd26e038aca158e19af32340ec8a58bc7b13dda3.
("Make git a test dependency of gitlib-cmdline."
and "Make git a test dependency of hlibgit2.")

The downside of this change is that if git is missing it will no
longer be flagged by cabal.