### PR TITLE
Fix constraint mismatch

### DIFF
--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -6,7 +6,6 @@
 module Git.Types where
 
 import           Conduit
-import           Control.Applicative
 import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Trans.State
@@ -16,7 +15,6 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.HashMap.Strict (HashMap)
 import           Data.Hashable
 import           Data.Map (Map)
-import           Data.Semigroup
 import           Data.Tagged
 import           Data.Text (Text)
 import qualified Data.Text as T
@@ -137,7 +135,7 @@ newtype SHA = SHA { getSHA :: ByteString } deriving (Eq, Ord, Read)
 shaToText :: SHA -> Text
 shaToText (SHA bs) = T.decodeUtf8 (B16.encode bs)
 
-textToSha :: Monad m => Text -> m SHA
+textToSha :: MonadFail m => Text -> m SHA
 textToSha t =
     case B16.decode $ T.encodeUtf8 t of
         (bs, "") -> return (SHA bs)

--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -8,6 +8,7 @@ module Git.Types where
 import           Conduit
 import           Control.Exception
 import           Control.Monad
+import           Control.Monad.Fail
 import           Control.Monad.Trans.State
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16

--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -6,6 +6,7 @@
 module Git.Types where
 
 import           Conduit
+import           Control.Applicative
 import           Control.Exception
 import           Control.Monad
 import           Control.Monad.Fail (MonadFail)
@@ -16,6 +17,7 @@ import qualified Data.ByteString.Lazy as BL
 import           Data.HashMap.Strict (HashMap)
 import           Data.Hashable
 import           Data.Map (Map)
+import           Data.Semigroup
 import           Data.Tagged
 import           Data.Text (Text)
 import qualified Data.Text as T

--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -7,8 +7,8 @@ module Git.Types where
 
 import           Conduit
 import           Control.Exception
-import           Control.Monad ( (<=<), forM_ )
-import           Control.Monad.Fail
+import           Control.Monad
+import           Control.Monad.Fail (MonadFail)
 import           Control.Monad.Trans.State
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16

--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -7,7 +7,7 @@ module Git.Types where
 
 import           Conduit
 import           Control.Exception
-import           Control.Monad
+import           Control.Monad ( (<=<), forM_ )
 import           Control.Monad.Fail
 import           Control.Monad.Trans.State
 import           Data.ByteString (ByteString)

--- a/gitlib/gitlib.cabal
+++ b/gitlib/gitlib.cabal
@@ -40,7 +40,7 @@ Library
     default-language:   Haskell98
     ghc-options: -Wall
     build-depends:
-          base                 >= 3 && < 5
+          base                 == 4.11.1.0
         , base16-bytestring    >= 0.1.1.5
         , bytestring           >= 0.9.2.1
         , conduit              >= 1.2.8

--- a/gitlib/gitlib.cabal
+++ b/gitlib/gitlib.cabal
@@ -40,7 +40,7 @@ Library
     default-language:   Haskell98
     ghc-options: -Wall
     build-depends:
-          base                 == 4.11.1.0
+          base                 >= 3 && < 5
         , base16-bytestring    >= 0.1.1.5
         , bytestring           >= 0.9.2.1
         , conduit              >= 1.2.8


### PR DESCRIPTION
The current code uses `fail` in the context of the typeclass `Monad`, while it is actually defined in `MonadFail`. I ran into this issue while attempting to build with latest versions of base etc.