### PR TITLE
Add in missing MonadFail constraint for GHC 8.8

### DIFF
--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -137,7 +137,7 @@ newtype SHA = SHA { getSHA :: ByteString } deriving (Eq, Ord, Read)
 shaToText :: SHA -> Text
 shaToText (SHA bs) = T.decodeUtf8 (B16.encode bs)
 
-textToSha :: Monad m => Text -> m SHA
+textToSha :: (MonadFail m, Monad m) => Text -> m SHA
 textToSha t =
     case B16.decode $ T.encodeUtf8 t of
         (bs, "") -> return (SHA bs)

--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -9,6 +9,7 @@ import           Conduit
 import           Control.Applicative
 import           Control.Exception
 import           Control.Monad
+import           Control.Monad.Fail (MonadFail)
 import           Control.Monad.Trans.State
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16


### PR DESCRIPTION
GHC has been moving to towards removing `fail` and `MonadFail`
from `Monad` as documented in the MonadFail proposal [0].

This was a warning until GHC 8.8 where it's now a compilation failure
[1] as the `fail` method has been removed from `Monad`.

Add in the missing constraint.

[0] https://gitlab.haskell.org/haskell/prime/-/wikis/libraries/proposals/monad-fail
[1] https://downloads.haskell.org/~ghc/8.8.1/docs/html/users_guide/8.8.1-notes.html#base-library