### PR TITLE
Add support for git_diff_tree_to_tree

### DIFF
--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -401,6 +401,7 @@ data GitException
     | DiffBlobFailed Text
     | DiffPrintToPatchFailed Text
     | DiffTreeToIndexFailed Text
+    | DiffTreeToTreeFailed Text
     | IndexAddFailed TreeFilePath Text
     | IndexCreateFailed Text
     | PathEncodingError Text


### PR DESCRIPTION
This adds a method to gitlib to perform diffs between trees. The data
types that are intended to be created by the method are general and
cover most bases for the `git_diff_tree_to_tree` function. An
implemention is added to gitlib-libgit2.

Closes #71