### PR TITLE
git-ignored .stack-works folders generated by stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ fpbuild/
 /vendor/
 result
 tags
+.stack-work


### PR DESCRIPTION
These are created in the case where gitlib is compiled as a sub-project
of an unrelated project that uses stack rather than cabal.