### PR TITLE
re conduit deprecations: use ConduitT directly

### DIFF
--- a/gitlib-cmdline/Git/CmdLine.hs
+++ b/gitlib-cmdline/Git/CmdLine.hs
@@ -372,7 +372,7 @@ cliExistsObject (shaToText -> sha) = do
 
 cliSourceObjects :: MonadCli m
                  => Maybe (CommitOid CliRepo) -> CommitOid CliRepo -> Bool
-                 -> Producer (ReaderT CliRepo m) (ObjectOid CliRepo)
+                 -> ConduitT i (ObjectOid CliRepo) (ReaderT CliRepo m ())
 cliSourceObjects mhave need alsoTrees = do
     shas <- lift $ doRunGit run
             ([ "--no-pager", "log", "--format=%H %T" ]
@@ -496,7 +496,7 @@ cliTreeEntry tree fp = do
 
 cliSourceTreeEntries :: MonadCli m
                      => Tree CliRepo
-                     -> Producer (ReaderT CliRepo m) (TreeFilePath, TreeEntry CliRepo)
+                     -> ConduitT i (TreeFilePath, TreeEntry CliRepo) (ReaderT CliRepo m ())
 cliSourceTreeEntries tree = do
     contents <- lift $ do
         toid <- treeOid tree
@@ -633,7 +633,7 @@ cliUpdateRef refName (RefSymbolic targetName) =
 cliDeleteRef :: MonadCli m => Text -> ReaderT CliRepo m ()
 cliDeleteRef refName = runGit_ ["update-ref", "-d", fromStrict refName]
 
-cliSourceRefs :: MonadCli m => Producer (ReaderT CliRepo m) Text
+cliSourceRefs :: MonadCli m => ConduitT i Text (ReaderT CliRepo m ())
 cliSourceRefs = do
     mxs <- lift $ cliShowRef Nothing
     yieldMany $ case mxs of

--- a/gitlib-hit/Git/Hit.hs
+++ b/gitlib-hit/Git/Hit.hs
@@ -380,7 +380,7 @@ hitWriteTree entMap = do
     fmap Tagged $ liftIO $ DGS.setObject g $ DGO.ObjTree $ DGT.Tree ents
 
 
-hitSourceRefs :: MonadHit m => Producer (ReaderT HitRepo m) Text
+hitSourceRefs :: MonadHit m => ConduitT i Text (ReaderT HitRepo m ())
 hitSourceRefs = do
     g <- lift $ hitGit <$> getRepository
     -- TODO: this produces branches & tags, but not remotes
@@ -394,7 +394,7 @@ hitSourceRefs = do
 
 hitSourceTreeEntries :: MonadHit m
                      => Tree HitRepo
-                     -> Producer (ReaderT HitRepo m) TreePathEntry
+                     -> ConduitT i TreePathEntry (ReaderT HitRepo m ())
 hitSourceTreeEntries (HitTree oid) = do
     g <- lift $ hitGit <$> getRepository
     ents <- liftIO $ readTreeRecurse "" (untag oid) g


### PR DESCRIPTION
Fixes conduit related compile errors e.g.:
```
gitlib-libgit2>       Expected: Maybe (Git.CommitOid LgRepo)
gitlib-libgit2>                 -> Git.CommitOid LgRepo
gitlib-libgit2>                 -> Bool
gitlib-libgit2>                 -> ConduitT i (Git.ObjectOid LgRepo) m ()
gitlib-libgit2>         Actual: Maybe CommitOid
gitlib-libgit2>                 -> CommitOid -> Bool -> Producer m0 ObjectOid
gitlib-libgit2>     • In the expression: lgSourceObjects
gitlib-libgit2>       In an equation for ‘Git.sourceObjects’:
gitlib-libgit2>           Git.sourceObjects = lgSourceObjects
gitlib-libgit2>       In the instance declaration for ‘Git.MonadGit LgRepo m’
gitlib-libgit2>     • Relevant bindings include
gitlib-libgit2>         sourceObjects :: Maybe (Git.CommitOid LgRepo)
gitlib-libgit2>                          -> Git.CommitOid LgRepo
gitlib-libgit2>                          -> Bool
gitlib-libgit2>                          -> ConduitT i (Git.ObjectOid LgRepo) m ()
gitlib-libgit2>           (bound at Git/Libgit2.hs:214:5)
gitlib-libgit2>     |
gitlib-libgit2> 214 |     sourceObjects     = lgSourceObjects
```
Conduit note for reference: https://github.com/snoyberg/conduit#terminology-and-concepts