### PR TITLE
Bump base16-bytestring major version

### DIFF
--- a/gitlib/gitlib.cabal
+++ b/gitlib/gitlib.cabal
@@ -41,7 +41,7 @@ Library
     ghc-options: -Wall
     build-depends:
           base                 >= 3 && < 5
-        , base16-bytestring    >= 0.1.1.5 && < 1.0.0.0
+        , base16-bytestring    >= 1.0.0.0 && < 2.0.0.0
         , bytestring           >= 0.9.2.1
         , conduit              >= 1.2.8
         , conduit-combinators  >= 1


### PR DESCRIPTION
This fixes compilation errors, and compilation works with the update.