### PR TITLE
Change listTreeEntries and sourceTreeEntries to take a recursive::Bool argument

### DIFF
--- a/gitlib-cmdline/gitlib-cmdline.cabal
+++ b/gitlib-cmdline/gitlib-cmdline.cabal
@@ -1,5 +1,5 @@
 Name:                gitlib-cmdline
-Version:             3.1.0.2
+Version:             3.2.0.2
 Synopsis:            Gitlib repository backend that uses the git command-line tool.
 Description:         Gitlib repository backend that uses the git command-line tool.
 License-file:        LICENSE

--- a/gitlib-hit/gitlib-hit.cabal
+++ b/gitlib-hit/gitlib-hit.cabal
@@ -1,5 +1,5 @@
 Name:                gitlib-hit
-Version:             3.1.0
+Version:             3.2.0
 Synopsis:            Gitlib repository backend that uses the pure-Haskell Hit library.
 Description:         Gitlib repository backend that uses the pure-Haskell Hit library.
 License-file:        LICENSE

--- a/gitlib-libgit2/Git/Libgit2.hs
+++ b/gitlib-libgit2/Git/Libgit2.hs
@@ -369,10 +369,11 @@ gatherFrom' size scatter = do
 
 lgSourceTreeEntries
     :: (MonadLg m, HasLgRepo m)
-    => Tree
+    => Bool
+    -> Tree
     -> ConduitT i (Git.TreeFilePath, TreeEntry) m ()
-lgSourceTreeEntries (LgTree Nothing) = return ()
-lgSourceTreeEntries (LgTree (Just tree)) = gatherFrom' 16 $ \queue -> do
+lgSourceTreeEntries _recursive (LgTree Nothing) = return ()
+lgSourceTreeEntries recursive (LgTree (Just tree)) = gatherFrom' 16 $ \queue -> do
     liftIO $ withForeignPtr tree $ \tr -> do
         r <- bracket
                 (mk'git_treewalk_cb (callback queue))
@@ -381,6 +382,7 @@ lgSourceTreeEntries (LgTree (Just tree)) = gatherFrom' 16 $ \queue -> do
                   c'git_tree_walk tr c'GIT_TREEWALK_PRE callback nullPtr)
         when (r < 0) $ lgThrow Git.TreeWalkFailed
   where
+    result = if recursive then 0 else 1
     callback queue root te _payload = do
         fp    <- peekFilePath root
         cname <- c'git_tree_entry_name te
@@ -388,7 +390,7 @@ lgSourceTreeEntries (LgTree (Just tree)) = gatherFrom' 16 $ \queue -> do
         entry <- entryToTreeEntry te
         atomically $
             writeTBQueue queue $ name `seq` entry `seq` (name,entry)
-        return 0
+        return result
 
 lgMakeBuilder :: (MonadLg m, HasLgRepo m)
               => ForeignPtr C'git_treebuilder -> TreeBuilder m

--- a/gitlib-libgit2/Git/Libgit2.hs
+++ b/gitlib-libgit2/Git/Libgit2.hs
@@ -1049,7 +1049,7 @@ lgDiffContentsWithTree contents tree = do
   where
     -- generateDiff :: MonadLg m => LgRepo -> TBQueue ByteString -> m ()
     generateDiff repo chan = do
-        entries   <- M.fromList <$> Git.listTreeEntries tree
+        entries   <- M.fromList <$> Git.listTreeEntries True tree
         paths     <- liftIO $ newIORef []
         (src, ()) <- contents $$+ return ()
 

--- a/gitlib-libgit2/gitlib-libgit2.cabal
+++ b/gitlib-libgit2/gitlib-libgit2.cabal
@@ -1,5 +1,5 @@
 Name:                gitlib-libgit2
-Version:             3.1.2.1
+Version:             3.2.2.1
 Synopsis:            Libgit2 backend for gitlib
 License-file:        LICENSE
 License:             MIT

--- a/gitlib-test/Git/Smoke.hs
+++ b/gitlib-test/Git/Smoke.hs
@@ -280,7 +280,7 @@ smokeTestSpec pr _pr2 = describe "Smoke tests" $ do
       createCommit [] tree sig sig "Initial commit" (Just masterRef)
 
       tree' <- lookupTree tree
-      paths <- map fst <$> listTreeEntries tree'
+      paths <- map fst <$> listTreeEntries True tree'
       liftIO $ sort paths @?= [ "Files"
                               , "Files/Three"
                               , "Five"
@@ -451,7 +451,7 @@ doTreeit label pr kinds action = withNewRepository pr fullPath $ do
             _ -> do
                 liftIO $ isBlobKind kind @?= False
                 liftIO $ throwIO (TreeitException "Entry is of unexpected kind")
-    paths <- map fst <$> listTreeEntries tree
+    paths <- map fst <$> listTreeEntries True tree
     liftIO $ sort paths @?= map kindPath kinds
   where
     fullPath  = normalize label <> ".git"

--- a/gitlib-test/Git/Smoke.hs
+++ b/gitlib-test/Git/Smoke.hs
@@ -291,6 +291,13 @@ smokeTestSpec pr _pr2 = describe "Smoke tests" $ do
                               , "One"
                               , "Two"
                               ]
+      paths <- map fst <$> listTreeEntries False tree'
+      liftIO $ sort paths @?= [ "Files"
+                              , "Five"
+                              , "More"
+                              , "One"
+                              , "Two"
+                              ]
 
   treeit "adds a file" pr
       [ Bl "one"

--- a/gitlib-test/gitlib-test.cabal
+++ b/gitlib-test/gitlib-test.cabal
@@ -1,5 +1,5 @@
 Name:                gitlib-test
-Version:             3.1.1
+Version:             3.2.1
 Synopsis:            Test library for confirming gitlib backend compliance
 License-file:        LICENSE
 License:             MIT

--- a/gitlib/Git/Blob.hs
+++ b/gitlib/Git/Blob.hs
@@ -60,7 +60,7 @@ sourceTreeBlobEntries
     :: MonadGit r m
     => Tree r -> ConduitT i (TreeFilePath, BlobOid r, BlobKind) m ()
 sourceTreeBlobEntries tree =
-    sourceTreeEntries tree .| awaitForever go
+    sourceTreeEntries True tree .| awaitForever go
   where
     go (fp ,BlobEntry oid k) = yield (fp, oid, k)
     go _ = return ()

--- a/gitlib/Git/Object.hs
+++ b/gitlib/Git/Object.hs
@@ -29,7 +29,7 @@ expandTreeObjects = awaitForever $ \obj -> case obj of
     TreeObjOid toid -> do
         yield $ TreeObjOid toid
         tr <- lift $ lookupTree toid
-        sourceTreeEntries tr
+        sourceTreeEntries True tr
             .| awaitForever (\ent -> case ent of
                 (_, BlobEntry oid _) -> yield $ BlobObjOid oid
                 (_, TreeEntry oid)   -> yield $ TreeObjOid oid

--- a/gitlib/Git/Tree.hs
+++ b/gitlib/Git/Tree.hs
@@ -11,7 +11,7 @@ import           Git.Tree.Builder
 import           Git.Types
 
 listTreeEntries :: MonadGit r m => Tree r -> m [(TreeFilePath, TreeEntry r)]
-listTreeEntries tree = runConduit $ sourceTreeEntries tree .| sinkList
+listTreeEntries tree = runConduit $ sourceTreeEntries True tree .| sinkList
 
 copyTreeEntry :: (MonadGit r m, MonadGit s (t m), MonadTrans t)
               => TreeEntry r -> HashSet Text -> t m (TreeEntry s, HashSet Text)

--- a/gitlib/Git/Tree.hs
+++ b/gitlib/Git/Tree.hs
@@ -10,8 +10,10 @@ import           Git.Blob
 import           Git.Tree.Builder
 import           Git.Types
 
-listTreeEntries :: MonadGit r m => Tree r -> m [(TreeFilePath, TreeEntry r)]
-listTreeEntries tree = runConduit $ sourceTreeEntries True tree .| sinkList
+-- | Return the list of names and entries in the tree. Recurse in to all
+-- subtrees when the boolean is true.
+listTreeEntries :: MonadGit r m => Bool -> Tree r -> m [(TreeFilePath, TreeEntry r)]
+listTreeEntries recursive tree = runConduit $ sourceTreeEntries recursive tree .| sinkList
 
 copyTreeEntry :: (MonadGit r m, MonadGit s (t m), MonadTrans t)
               => TreeEntry r -> HashSet Text -> t m (TreeEntry s, HashSet Text)
@@ -35,7 +37,7 @@ copyTree tr needed = do
     if HashSet.member sha needed
         then do
         tree    <- lift $ lookupTree tr
-        entries <- lift $ listTreeEntries tree
+        entries <- lift $ listTreeEntries True tree
         (needed', tref) <-
             withNewTree $ foldM doCopyTreeEntry needed entries
 

--- a/gitlib/Git/Types.hs
+++ b/gitlib/Git/Types.hs
@@ -80,7 +80,7 @@ class (Applicative m, Monad m, MonadThrow m,
 
     treeOid   :: Tree r -> m (TreeOid r)
     treeEntry :: Tree r -> TreeFilePath -> m (Maybe (TreeEntry r))
-    sourceTreeEntries :: Tree r -> ConduitT i (TreeFilePath, TreeEntry r) m ()
+    sourceTreeEntries :: Bool -> Tree r -> ConduitT i (TreeFilePath, TreeEntry r) m ()
 
     diffContentsWithTree :: ConduitT () (Either TreeFilePath ByteString) m ()
                          -> Tree r -> ConduitT i ByteString m ()

--- a/gitlib/Git/Working.hs
+++ b/gitlib/Git/Working.hs
@@ -19,7 +19,7 @@ checkoutFiles :: (MonadGit r m, MonadResource m)
               -> Bool
               -> m ()
 checkoutFiles destPath tree decode cloneSubmodules =
-    runConduit $ sourceTreeEntries tree .| (mapM_C $ \(path, entry) ->
+    runConduit $ sourceTreeEntries True tree .| (mapM_C $ \(path, entry) ->
         case (destPath </>) <$> decode path of
             Left e ->  decodeError path e
             Right fullPath -> do

--- a/gitlib/gitlib.cabal
+++ b/gitlib/gitlib.cabal
@@ -1,5 +1,5 @@
 Name:          gitlib
-Version:       3.1.3
+Version:       3.2.3
 Synopsis:      API library for working with Git repositories
 License-file:  LICENSE
 License:       MIT


### PR DESCRIPTION
This PR addresses https://github.com/jwiegley/gitlib/issues/64 by adding a `recursive::Bool` argument to the user-interface function `listTreeEntries` and to the library-backend interface function `sourceTreeEntries` and modulating the `git_tree_walk` callback to return `0` when a recursive traversal is required or return `1` when only immediate children are desired. In this way, `listTreeEntries` can be used for either walking the whole repo or listing a single tree object's immediate members. Unfortunately, it is a breaking change.

* [x] gitlib - updated and works
* [x] gitlib-test - updated and works
* [x] gitlib-libgit2 - updated and works
* [x] gitlib-cmdline - todo
* [x] gitlib-hit - todo
* ~~git-monitor~~ (does not call the changed functions; already compiles with no changes)
* ~~hlibgit2~~ (does not depend on `gitlib`)
* [x] bump version from `3.1.x` to `3.2.x` for each changed package