### PR TITLE
bump version of hlibgit2

### DIFF
--- a/hlibgit2/hlibgit2.cabal
+++ b/hlibgit2/hlibgit2.cabal
@@ -1,5 +1,5 @@
 Name:                hlibgit2
-Version:             0.18.0.16
+Version:             0.18.0.17
 Synopsis:            Low-level bindings to libgit2
 Description:         Bindings to libgit2 v0.18.0.
 License-file:        LICENSE


### PR DESCRIPTION
This incorporates the previous change https://github.com/jwiegley/gitlib/commit/5fc31eff3c45a7ca8aa9aa9ab46ab17a4ddbe927 that changes the `Build-Type` from `Custom` to `Simple`.

This removes an implicit dependency on `setup.Cabal >=1.9 && <1.25` allowing the latest version to be built when built as a dependency of a project using a newer cabal version.